### PR TITLE
Rename scope to playlist-modify-public

### DIFF
--- a/eg/add_tracks_to_playlists.pl
+++ b/eg/add_tracks_to_playlists.pl
@@ -11,7 +11,7 @@ unless ($username and $playlist_id and @track_ids) {
   exit;
 }
 
-my $scope = 'playlist-modify';
+my $scope = 'playlist-modify-public';
 my $token = WebService::Spotify::Util::prompt_for_user_token($username, $scope);
 
 if ($token) {


### PR DESCRIPTION
Spotify's Web API has renamed the `playlist-modify` scope to `playlist-modify-public` to better describe what it allows. Even though the old one will be supported for some time, the new one is the preferred way to go.
