### PR TITLE
Bug fix: function should pass in a key called "field" not contents of "$field"

### DIFF
--- a/lib/WebService/Spotify.pm
+++ b/lib/WebService/Spotify.pm
@@ -130,7 +130,7 @@ method user_playlists ($user_id) {
 
 method user_playlist ($user_id, :$playlist_id, :$fields) {
   my $method = $playlist_id ? "playlists/$playlist_id" : "starred";
-  return $self->get("users/$user_id/$method", $fields => $fields);
+  return $self->get("users/$user_id/$method", fields => $fields);
 }
 
 method user_playlist_create ($user_id, $name, :$public = 1) {


### PR DESCRIPTION
As it stands, it uses the contents of the $field var passed in by user as the name of the argument. 
